### PR TITLE
Replaced tk.Text to ctk.CTkTextbox

### DIFF
--- a/src/editing_mode.py
+++ b/src/editing_mode.py
@@ -67,7 +67,7 @@ def editing_mode(self, file_path, uid):
     # I REMOVED THE SCROLLBARS BECAUSE WHEN THE TEXT DOESN'T FIT, THEY APPEAR THEMSELVES.
 
     # Scrolled text widget with horizontal scrolling
-    text_area = ctk.CTkTextbox(frame, wrap=tk.NONE, undo=True)
+    text_area = ctk.CTkTextbox(frame, wrap=tk.NONE, undo=True, font=self.tk_font)
     text_area.pack(side=tk.LEFT, padx=2, pady=2, fill=tk.BOTH, expand=True)
 
     # Store the current file path and text area for Save functionality

--- a/src/editing_mode.py
+++ b/src/editing_mode.py
@@ -1,4 +1,3 @@
-from tkinter import scrolledtext
 import tkinter as tk
 import customtkinter as ctk
 from encryption import generate_key, encrypt_message
@@ -62,24 +61,14 @@ def editing_mode(self, file_path, uid):
     title_label.pack(pady=(10, 5))
 
     # Frame to hold the text area and scrollbars
-    frame = tk.Frame(self.master)
+    frame = ctk.CTkFrame(self.master)
     frame.pack(padx=10, pady=10, fill=tk.BOTH, expand=True)
 
-    # Horizontal scrollbar
-    h_scroll = tk.Scrollbar(frame, orient=tk.HORIZONTAL)
-    h_scroll.pack(side=tk.BOTTOM, fill=tk.X)
-
-    # Vertical scrollbar
-    v_scroll = tk.Scrollbar(frame, orient=tk.VERTICAL)
-    v_scroll.pack(side=tk.RIGHT, fill=tk.Y)
+    # I REMOVED THE SCROLLBARS BECAUSE WHEN THE TEXT DOESN'T FIT, THEY APPEAR THEMSELVES.
 
     # Scrolled text widget with horizontal scrolling
-    text_area = tk.Text(frame, wrap=tk.NONE, xscrollcommand=h_scroll.set, yscrollcommand=v_scroll.set, undo=True, borderwidth=0, highlightthickness=0)
+    text_area = ctk.CTkTextbox(frame, wrap=tk.NONE, undo=True)
     text_area.pack(side=tk.LEFT, padx=2, pady=2, fill=tk.BOTH, expand=True)
-
-    # Configure scrollbars
-    h_scroll.config(command=text_area.xview)
-    v_scroll.config(command=text_area.yview)
 
     # Store the current file path and text area for Save functionality
     self.current_file_path = file_path

--- a/src/init.py
+++ b/src/init.py
@@ -3,7 +3,7 @@ import customtkinter as ctk
 import csv
 import os, sys
 import platform
-from CTkMenuBar import *
+from CTkMenuBar import CTkMenuBar, CustomDropdownMenu
 from PIL import Image
 from tkinter import filedialog, Text, PhotoImage
 import datetime

--- a/src/init.py
+++ b/src/init.py
@@ -57,7 +57,7 @@ class LightweightNotesApp:
         self.create_account_window = None
         self.editing = False 
         self.init_login_screen()
-        self.tk_font = None
+        self.tk_font = ctk.CTkFont(family="Arial Baltic", size=12)
 
     def init_login_screen(self):
         """

--- a/src/init.py
+++ b/src/init.py
@@ -16,7 +16,6 @@ from create_account import *
 
 """
 ToDo:
- * Implement"Change Font" functionality
  * Implement "Export" functionalities
 """
 
@@ -58,6 +57,7 @@ class LightweightNotesApp:
         self.create_account_window = None
         self.editing = False 
         self.init_login_screen()
+        self.tk_font = None
 
     def init_login_screen(self):
         """
@@ -179,7 +179,7 @@ class LightweightNotesApp:
 
         # Edit Dropdown
         edit_menu = CustomDropdownMenu(widget=opt_edit)
-        edit_menu.add_option(option="Change Font")
+        edit_menu.add_option(option="Change Font", command=self.change_font)
         edit_menu.add_option(option="Cut (CTRL + X)")
         edit_menu.add_option(option="Copy (CTRL + C)")
         edit_menu.add_option(option="Paste (CTRL + V)")
@@ -191,6 +191,20 @@ class LightweightNotesApp:
         # About Dropdown
         about_menu = CustomDropdownMenu(widget=opt_about)
         about_menu.add_option(option="About pt1 - Lightweight Notes", command=self.open_about)
+
+    def change_font(self):
+        def listbox_callback(event):
+            selected_font = fonts_listbox.get(fonts_listbox.curselection())
+            self.tk_font = ctk.CTkFont(family=selected_font, size=None)
+
+        font_dialog = ctk.CTkToplevel(self.master)
+
+        fonts = list(tk.font.families())
+        fonts_listbox = tk.Listbox(font_dialog)
+        fonts_listbox.pack(padx=10, pady=10)
+        for f in fonts:
+            fonts_listbox.insert(ctk.END, f)
+        fonts_listbox.bind("<<ListboxSelect>>", listbox_callback)
 
     def save_current_document(self):
         """


### PR DESCRIPTION
Hello! I replaced tk.Text in editing_mode.py with ctk.CTkTextbox. This widget is in the customtkinter library, it is more modern, supports dark theme and scrolling if there is a lot of text. Scrollbars are no longer needed.

![Снимок экрана_2025-05-20_13-13-33](https://github.com/user-attachments/assets/0d7b05a8-b6ab-4d99-9699-a139f9674552)

![Снимок экрана_2025-05-20_13-35-17](https://github.com/user-attachments/assets/072b242e-47b1-4361-8126-070d585877bf)
